### PR TITLE
Funciones de cadenas de caracteres faltantes en entornos UNIX

### DIFF
--- a/input.c
+++ b/input.c
@@ -201,8 +201,8 @@ int input_getChar(char* input, char message[], char eMessage[], char lowLimit, c
                 }
             }
 
+            setbuf(stdin, NULL); /**< Limpieza de buffer previo. */
             scanf("%c", &charValue);
-            input_clearBufferAfter();
         } while((int)charValue < (int)lowLimit || (int)charValue > (int)hiLimit);
 
         if((int)charValue >= (int)lowLimit && (int)charValue <= (int)hiLimit)
@@ -242,8 +242,8 @@ int input_getString(char* input, char message[], char eMessage[], int lowLimit, 
                 }
             }
 
-            /**< Metodo para escanear la cadena completa por mas que existan espacios */
-            if(scanf("%[^\n]s", auxMessage))
+            setbuf(stdin, NULL); /**< Limpieza de buffer previo. */
+            if(scanf("%[^\n]s", auxMessage)) /**< Metodo para escanear la cadena completa con espacios */
             {
                 sizeScan = strlen(auxMessage);
             }
@@ -251,8 +251,6 @@ int input_getString(char* input, char message[], char eMessage[], int lowLimit, 
             {
                 continue;
             }
-
-            input_clearBufferAfter();
         } while(sizeScan < lowLimit || sizeScan > hiLimit);
 
         if(sizeScan >= lowLimit && sizeScan <= hiLimit
@@ -270,20 +268,18 @@ int input_getString(char* input, char message[], char eMessage[], int lowLimit, 
     return returnValue;
 }
 
-int input_concatStrings(char* concatenatedString, char firstString[], char secondString[], int maxLenght)
+int input_concatStrings(char firstString[], char secondString[], int maxLenght)
 {
     int returnValue = -1;
     char auxString[STRING_MAX] = "";
 
-    if(concatenatedString != NULL && firstString != NULL && secondString != NULL
+    if(firstString != NULL && secondString != NULL
         && (strlen(firstString) + strlen(secondString)) < maxLenght && maxLenght < STRING_MAX)
     {
-        strncat(auxString, firstString, maxLenght);
-        strncat(auxString, secondString, maxLenght);
-        strncpy(concatenatedString, auxString, maxLenght);
+        strncat(firstString, secondString, maxLenght);
 
         /**< Se controla el uso de memoria agregando el caracter terminador. */
-        concatenatedString[maxLenght] = EXIT_BUFFER;
+        firstString[maxLenght] = EXIT_BUFFER;
         
         returnValue = 0;
     }

--- a/input.c
+++ b/input.c
@@ -44,7 +44,7 @@ void input_clearScreen()
 
 void input_pauseScreen(char message[])
 {
-    printf("%s...", message);
+    printf("%s", message);
 
     setbuf(stdin, NULL); /**< Limpieza de buffer previo. */
 

--- a/input.c
+++ b/input.c
@@ -260,7 +260,7 @@ int input_getString(char* input, char message[], char eMessage[], int lowLimit, 
             auxMessage[STRING_MAX-1] = EXIT_BUFFER;
 
             strcpy(input, auxMessage);
-            
+
             returnValue = 0;
         }
     }
@@ -271,20 +271,58 @@ int input_getString(char* input, char message[], char eMessage[], int lowLimit, 
 int input_concatStrings(char firstString[], char secondString[], int maxLenght)
 {
     int returnValue = -1;
-    char auxString[STRING_MAX] = "";
 
     if(firstString != NULL && secondString != NULL
-        && (strlen(firstString) + strlen(secondString)) < maxLenght && maxLenght < STRING_MAX)
+        && (strlen(firstString) + strlen(secondString)) < maxLenght
+        && maxLenght < STRING_MAX && maxLenght > 0)
     {
         strncat(firstString, secondString, maxLenght);
 
         /**< Se controla el uso de memoria agregando el caracter terminador. */
         firstString[maxLenght] = EXIT_BUFFER;
-        
+
         returnValue = 0;
     }
 
     return returnValue;
+}
+
+char* input_stringToUppercase(char string[], int maxLength)
+{
+    char* auxString = string;
+    int i = 0;
+
+    if(string != NULL && maxLength < STRING_MAX && maxLength > 0)
+    {
+        while(i <= maxLength || auxString[i] == EXIT_BUFFER)
+        {
+            auxString[i] = toupper((char)auxString[i]);
+            i++;
+        }
+
+        auxString[maxLength] = EXIT_BUFFER;
+    }
+
+    return auxString;
+}
+
+char* input_stringToLowercase(char string[], int maxLength)
+{
+    char* auxString = string;
+    int i = 0;
+
+    if(string != NULL && maxLength < STRING_MAX && maxLength > 0)
+    {
+        while(i <= maxLength || auxString[i] == EXIT_BUFFER)
+        {
+            auxString[i] = tolower((char)auxString[i]);
+            i++;
+        }
+
+        auxString[maxLength] = EXIT_BUFFER;
+    }
+
+    return auxString;
 }
 
 void input_printNumberByType(char message[], float number)

--- a/input.h
+++ b/input.h
@@ -110,6 +110,24 @@ int input_getString(char* input, char message[], char eMessage[], int lowLimit, 
  */
 int input_concatStrings(char firstString[], char secondString[], int maxLenght);
 
+/** \brief Devuelve la cadena de caracteres en mayusculas.
+ * 
+ *  \param string[] char Cadena de caracteres a pasar a mayusculas.
+ *  \param maxLength int Longitud maxima a pasar a mayusculas.
+ *  \return char* Puntero a cadena de caracteres pasada a mayusculas.
+ * 
+ */
+char* input_stringToUppercase(char string[], int maxLength);
+
+/** \brief Devuelve la cadena de caracteres en minusculas.
+ * 
+ *  \param string[] char Cadena de caracteres a pasar a minusculas.
+ *  \param maxLength int Longitud maxima a pasar a minusculas.
+ *  \return char* Puntero a cadena de caracteres pasada a minusculas.
+ * 
+ */
+char* input_stringToLowercase(char string[], int maxLength);
+
 /** \brief Funcion que imprime un numero en pantalla segun su tipo.
  *
  * \param message[] char Mensaje a imprimir antes del numero.

--- a/input.h
+++ b/input.h
@@ -102,14 +102,13 @@ int input_getString(char* input, char message[], char eMessage[], int lowLimit, 
 /** \brief Valida la concatenacion de dos cadenas
  *      controlando el longitud de la primer cadena por parametro.
  *
- * \param concatenatedString char* Cadena a concatenar las dos cadenas.
- * \param firstString[] char Primer cadena a concatenar.
- * \param secondString[] char Segunda cadena a concatenar.
+ * \param firstString[] char Primer cadena a concatenarse.
+ * \param secondString[] char Segunda cadena a concatenarse.
  * \param maxLenght int Longitud maxima para controlar la concatenacion.
  * \return void Si pudo realizar la concatenacion retorna [0] si no [-1].
  *
  */
-int input_concatStrings(char* concatenatedString, char firstString[], char secondString[], int maxLenght);
+int input_concatStrings(char firstString[], char secondString[], int maxLenght);
 
 /** \brief Funcion que imprime un numero en pantalla segun su tipo.
  *

--- a/main.c
+++ b/main.c
@@ -2,17 +2,16 @@
 
 int main()
 {
-    char string[STRING_MAX];
-    char firstString[] = "Hola ";
+    char firstString[STRING_MAX] = "Hola ";
     char secondString[51];
     
     input_clearScreen();
 
     if(!input_getString(secondString, "Ingrese su nombre: ", "Intente nuevamente: ", 2, 51))
     {
-        if(!input_concatStrings(string, firstString, secondString, 100))
+        if(!input_concatStrings(firstString, secondString, 100))
         {
-            input_pauseScreen(string);
+            input_pauseScreen(firstString);
         }
     }
 

--- a/main.c
+++ b/main.c
@@ -12,6 +12,8 @@ int main()
         if(!input_concatStrings(firstString, secondString, 100))
         {
             input_pauseScreen(firstString);
+            input_pauseScreen(input_stringToUppercase(firstString, 100));
+            input_pauseScreen(input_stringToLowercase(firstString, 100));
         }
     }
 

--- a/main.c
+++ b/main.c
@@ -2,20 +2,9 @@
 
 int main()
 {
-    char firstString[STRING_MAX] = "Hola ";
-    char secondString[51];
-    
     input_clearScreen();
 
-    if(!input_getString(secondString, "Ingrese su nombre: ", "Intente nuevamente: ", 2, 51))
-    {
-        if(!input_concatStrings(firstString, secondString, 100))
-        {
-            input_pauseScreen(firstString);
-            input_pauseScreen(input_stringToUppercase(firstString, 100));
-            input_pauseScreen(input_stringToLowercase(firstString, 100));
-        }
-    }
+    input_pauseScreen("Hola Mundo...");
 
     return 0;
 }


### PR DESCRIPTION
Se crean las siguientes funciones de cadenas de caracteres que no están implementadas en las librerías base de entornos UNIX:
1. `strupr` por `input_stringToUppercase`
1. `strlwr` por `input_stringToLowercase`

Se cierra el siguiente caso:
* Close #9